### PR TITLE
Bugfix: process deadlocks on large output

### DIFF
--- a/PdfAValidator/PdfAValidator.cs
+++ b/PdfAValidator/PdfAValidator.cs
@@ -180,7 +180,7 @@ namespace Codeuctivity
             using (AutoResetEvent outputWaitHandle = new AutoResetEvent(false))
             using (AutoResetEvent errorWaitHandle = new AutoResetEvent(false))
             {
-                process.OutputDataReceived += (sender, e) =>
+                process.OutputDataReceived += (_, e) =>
                 {
                     if (e.Data == null)
                     {
@@ -191,7 +191,7 @@ namespace Codeuctivity
                         outputBuilder.AppendLine(e.Data);
                     }
                 };
-                process.ErrorDataReceived += (sender, e) =>
+                process.ErrorDataReceived += (_, e) =>
                 {
                     if (e.Data == null)
                     {

--- a/PdfAValidator/PdfAValidator.cs
+++ b/PdfAValidator/PdfAValidator.cs
@@ -157,12 +157,7 @@ namespace Codeuctivity
                 process.StartInfo.EnvironmentVariables["JAVACMD"] = PathJava;
             }
 
-            process.Start();
-
-            var outputResult = GetStreamOutput(process.StandardOutput);
-            var errorResult = GetStreamOutput(process.StandardError);
-
-            process.WaitForExit();
+            WaitAndReceiveOutput(process, out var outputResult, out var errorResult);
 
             if (VeraPdfExitCodes.CanExitCodeBeParsed(process.ExitCode))
             {
@@ -176,6 +171,50 @@ namespace Codeuctivity
                 return veraPdfReport;
             }
             throw new VeraPdfException($"Calling VeraPdf exited with {process.ExitCode} caused an error: {errorResult}\nCustom JAVACMD: {PathJava}\nVeraPdfStartScript: {VeraPdfStartScript}");
+        }
+
+        private void WaitAndReceiveOutput(Process process, out string outputResult, out string errorResult)
+        {
+            StringBuilder outputBuilder = new StringBuilder();
+            StringBuilder errorBuilder = new StringBuilder();
+            using (AutoResetEvent outputWaitHandle = new AutoResetEvent(false))
+            using (AutoResetEvent errorWaitHandle = new AutoResetEvent(false))
+            {
+                process.OutputDataReceived += (sender, e) =>
+                {
+                    if (e.Data == null)
+                    {
+                        outputWaitHandle.Set();
+                    }
+                    else
+                    {
+                        outputBuilder.AppendLine(e.Data);
+                    }
+                };
+                process.ErrorDataReceived += (sender, e) =>
+                {
+                    if (e.Data == null)
+                    {
+                        errorWaitHandle.Set();
+                    }
+                    else
+                    {
+                        errorBuilder.AppendLine(e.Data);
+                    }
+                };
+
+                process.Start();
+
+                process.BeginOutputReadLine();
+                process.BeginErrorReadLine();
+
+                process.WaitForExit();
+                outputWaitHandle.WaitOne();
+                errorWaitHandle.WaitOne();
+
+                outputResult = outputBuilder.ToString();
+                errorResult = errorBuilder.ToString();
+            }
         }
 
         private bool IsSingleFolder(IEnumerable<string> pathsToPdfFiles)
@@ -216,14 +255,6 @@ namespace Codeuctivity
             {
                 throw new VeraPdfException($"Failed to parse VeraPdf Output: {outputResult}\nCustom JAVACMD: {customJavaCmd}\nveraPdfStartScriptPath: {veraPdfStartScript}", xmlException);
             }
-        }
-
-        private static string GetStreamOutput(StreamReader stream)
-        {
-            //Read output in separate task to avoid deadlocks
-            var outputReadTask = Task.Run(() => stream.ReadToEnd());
-
-            return outputReadTask.Result;
         }
 
         private static T DeserializeXml<T>(string sourceXML) where T : class

--- a/PdfAValidatorTest/PdfAValidatorTest.cs
+++ b/PdfAValidatorTest/PdfAValidatorTest.cs
@@ -1,4 +1,5 @@
 ﻿using Codeuctivity;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -152,6 +153,37 @@ namespace CodeuctivityTest
             Assert.Equal("1", result.BatchSummary.ValidationReports.Compliant);
             Assert.Equal("2", result.BatchSummary.ValidationReports.NonCompliant);
             Assert.Equal("3", result.BatchSummary.ValidationReports.FailedJobs);
+        }
+
+        [Fact]
+        public static async Task ShouldNotDeadlockWhenValidatingFolderThatCausesLargeOutput()
+        {
+            // Setup folder with pdf files that causes large output streams
+            string tmpDirName = "./TestPdfFilesTmp";
+            if (Directory.Exists(tmpDirName))
+            {
+                Directory.Delete(tmpDirName, true);
+            }
+            Directory.CreateDirectory(tmpDirName);
+            var sourceDir = new DirectoryInfo("./TestPdfFiles");
+            foreach (var file in sourceDir.GetFiles())
+            {
+                for (int i = 0; i <= 7; i++)
+                {
+                    file.CopyTo(Path.Combine(tmpDirName, $"{file.Name}{i}.pdf"));
+                }
+            }
+
+            var pdfAValidator = new PdfAValidator();
+            var task = pdfAValidator.ValidateWithDetailedReportAsync(tmpDirName, "");
+
+            bool completedTask = task.Wait(TimeSpan.FromMinutes(1));
+            Assert.True(completedTask);
+            if (completedTask)
+            {
+                var result = await task;
+                Assert.Equal("42", result.BatchSummary.TotalJobs);
+            }
         }
 
         [Fact]

--- a/PdfAValidatorTest/PdfAValidatorTest.cs
+++ b/PdfAValidatorTest/PdfAValidatorTest.cs
@@ -168,7 +168,7 @@ namespace CodeuctivityTest
             var sourceDir = new DirectoryInfo("./TestPdfFiles");
             foreach (var file in sourceDir.GetFiles())
             {
-                for (int i = 0; i <= 7; i++)
+                for (int i = 0; i <= 9; i++)
                 {
                     file.CopyTo(Path.Combine(tmpDirName, $"{file.Name}{i}.pdf"));
                 }
@@ -182,7 +182,7 @@ namespace CodeuctivityTest
             if (completedTask)
             {
                 var result = await task;
-                Assert.Equal("42", result.BatchSummary.TotalJobs);
+                Assert.Equal("60", result.BatchSummary.TotalJobs);
             }
         }
 


### PR DESCRIPTION
Fix a bug that occurs when validating a "large" folder of PDF:s (around 40 is often enough). This causes the output buffers of the process to fill and deadlocks in the current code. 

A fix is proposed in this SO: https://stackoverflow.com/questions/139593/processstartinfo-hanging-on-waitforexit-why?lq=1. I have implemented it and created a test to go with it. Now it does not deadlock.